### PR TITLE
Windows embedded Python

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -5,25 +5,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  # 9/29/2024: Uncommented the Windows EXE build in favor the embedded build method
-  # build-windows:
-  #   runs-on: windows-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v5
-  #     - name: Install and Build
-  #       run: |
-  #         python -m venv .
-  #         .\Scripts\activate
-  #         pip install -e .[win,build]
-  #         mkdir -p dist\windows
-  #         .\build_windows_exe.ps1 -NoCodeSign
-  #     - name: Upload build artifact
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: windows
-  #         path: dist\windows\piidigger.zip
   build-ubuntu:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -13,16 +13,15 @@ jobs:
         uses: actions/setup-python@v5
       - name: Install and Build
         run: |
-          python -m venv .
+          python -m venv .venv
           .\Scripts\activate
-          pip install -e .[win,build]
-          mkdir -p dist\windows
-          .\build_windows_exe.ps1 -NoCodeSign
+          pip install -e .[win]
+          build_windows_embedded.ps1 -arch amd64 -pyVersion 3.12.6 -venv .venv
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: windows
-          path: dist\windows\piidigger.zip
+          path: dist\
   build-ubuntu:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -5,24 +5,25 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-      - name: Install and Build
-        run: |
-          python -m venv .
-          .\Scripts\activate
-          pip install -e .[win,build]
-          mkdir -p dist\windows
-          .\build_windows_exe.ps1 -NoCodeSign
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: windows
-          path: dist\windows\piidigger.zip
+  # 9/29/2024: Uncommented the Windows EXE build in favor the embedded build method
+  # build-windows:
+  #   runs-on: windows-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v5
+  #     - name: Install and Build
+  #       run: |
+  #         python -m venv .
+  #         .\Scripts\activate
+  #         pip install -e .[win,build]
+  #         mkdir -p dist\windows
+  #         .\build_windows_exe.ps1 -NoCodeSign
+  #     - name: Upload build artifact
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: windows
+  #         path: dist\windows\piidigger.zip
   build-ubuntu:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -13,15 +13,16 @@ jobs:
         uses: actions/setup-python@v5
       - name: Install and Build
         run: |
-          python -m venv .venv
+          python -m venv .
           .\Scripts\activate
-          pip install -e .[win]
-          build_windows_embedded.ps1 -arch amd64 -pyVersion 3.12.6 -venv .venv
+          pip install -e .[win,build]
+          mkdir -p dist\windows
+          .\build_windows_exe.ps1 -NoCodeSign
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: windows
-          path: dist\
+          path: dist\windows\piidigger.zip
   build-ubuntu:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/embedded-build.yml
+++ b/.github/workflows/embedded-build.yml
@@ -1,4 +1,4 @@
-name: Build Embedded
+name: Build Windows Embedded
 on:
   push:
   workflow_dispatch:
@@ -13,7 +13,7 @@ jobs:
       - name: Install and Build
         run: |
           python -m venv .venv
-          .\Scripts\activate
+          .venv\Scripts\activate
           pip install -e .[win]
           build_windows_embedded.ps1 -arch amd64 -pyVersion 3.12.6 -venv .venv
       - name: Upload build artifact

--- a/.github/workflows/embedded-build.yml
+++ b/.github/workflows/embedded-build.yml
@@ -1,0 +1,23 @@
+name: Build Embedded
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+      - name: Install and Build
+        run: |
+          python -m venv .venv
+          .\Scripts\activate
+          pip install -e .[win]
+          build_windows_embedded.ps1 -arch amd64 -pyVersion 3.12.6 -venv .venv
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-amd64
+          path: dist\

--- a/.github/workflows/embedded-build.yml
+++ b/.github/workflows/embedded-build.yml
@@ -3,6 +3,11 @@ on:
   push:
   workflow_dispatch:
 
+env:
+  py_version: "3.12.6"
+  arch: "amd64"
+  venv: ".venv"
+
 jobs:
   build-windows:
     runs-on: windows-latest
@@ -12,12 +17,12 @@ jobs:
         uses: actions/setup-python@v5
       - name: Install and Build
         run: |
-          python -m venv .venv
-          .venv\Scripts\activate
+          python -m venv $venv
+          $venv\Scripts\activate
           pip install -e .[win]
-          .\build_windows_embedded.ps1 -arch amd64 -pyVersion 3.12.6 -venv .venv
+          .\build_windows_embedded.ps1 -arch $arch -pyVersion $py_version -venv $venv
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows-amd64
-          path: dist\
+          name: piidigger-$arch
+          path: dist\piidigger-$arch

--- a/.github/workflows/embedded-build.yml
+++ b/.github/workflows/embedded-build.yml
@@ -15,7 +15,7 @@ jobs:
           python -m venv .venv
           .venv\Scripts\activate
           pip install -e .[win]
-          build_windows_embedded.ps1 -arch amd64 -pyVersion 3.12.6 -venv .venv
+          .\build_windows_embedded.ps1 -arch amd64 -pyVersion 3.12.6 -venv .venv
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/embedded-build.yml
+++ b/.github/workflows/embedded-build.yml
@@ -1,7 +1,7 @@
 name: Build Windows Embedded
 on:
   push:
-    #branches: [main]
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/embedded-build.yml
+++ b/.github/workflows/embedded-build.yml
@@ -1,12 +1,9 @@
 name: Build Windows Embedded
 on:
   push:
+    #branches: [main]
   workflow_dispatch:
 
-env:
-  py_version: "3.12.6"
-  arch: "amd64"
-  
 jobs:
   build-windows:
     runs-on: windows-latest
@@ -19,9 +16,9 @@ jobs:
           python -m venv .venv
           .venv\Scripts\activate
           pip install -e .[win]
-          .\build_windows_embedded.ps1 -arch $arch -pyVersion $py_version -venv .venv
+          .\build_windows_embedded.ps1 -arch amd64 -pyVersion 3.12.6 -venv .venv
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: piidigger-$arch
-          path: dist\piidigger-$arch
+          name: piidigger-amd64
+          path: dist\piidigger-amd64

--- a/.github/workflows/embedded-build.yml
+++ b/.github/workflows/embedded-build.yml
@@ -6,8 +6,7 @@ on:
 env:
   py_version: "3.12.6"
   arch: "amd64"
-  venv: ".venv"
-
+  
 jobs:
   build-windows:
     runs-on: windows-latest
@@ -17,10 +16,10 @@ jobs:
         uses: actions/setup-python@v5
       - name: Install and Build
         run: |
-          python -m venv $venv
-          $venv\Scripts\activate
+          python -m venv .venv
+          .venv\Scripts\activate
           pip install -e .[win]
-          .\build_windows_embedded.ps1 -arch $arch -pyVersion $py_version -venv $venv
+          .\build_windows_embedded.ps1 -arch $arch -pyVersion $py_version -venv .venv
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ piidigger-logs/
 
 # Ignore macOS system files
 .DS_Store
+python.zip

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,9 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/
+*build/
 develop-eggs/
-dist/
+*dist/
 downloads/
 eggs/
 .eggs/
@@ -29,6 +29,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+compilation-report*.xml
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/ERRATA.md
+++ b/ERRATA.md
@@ -2,15 +2,8 @@
 ## Known Issues and Limitations
 A few items worth noting about PIIDigger:
 
-### Antivirus Alerts
-Building a binary/executable file in Python seems to trigger something in anti-virus software.  This problem seems to be alleviated by a different packaging method, but just in case Microsoft Defender warns reports that PIIDigger has a virus -- THE FILE IS SAFE. If your A/V triggers on PIIDigger, consider one of the following solutions:
-#### A/V Folder Exclusion
-1. Create an exception for the folder where you will dowload the PIIDigger executable binaries (e.g. `C:\Users\<username>\Downloads\Temp`).
-2. Save `piidigger.zip` to this folder and extract it
-3. Run it from there
-#### Install Python
-1. Install from the [Python Official Source](https://www.python.org/downloads/)
-2. Use the "Python Available" installation method included on the main PIIDigger page.  
+### Antivirus Alerts on Windows
+As we are now using Embedded Python directly from Python Software Foundation, virus detection problems should be a thing of the past.  Addtionally, we test all releases against VirusTotal to identify any potential issues.  However, if you receive a virus alert, please let us know through the Issues page on GitHub.
 
 NOTES:
 * For Windows users: There is also a Python download available in the Microsoft Store, but PIIDigger was not tested against this version.  #YMMV.

--- a/README.md
+++ b/README.md
@@ -52,15 +52,15 @@ PIIDigger will now be available as a program.  Run it with `piddigger` on the te
 
 PIIDigger will now be available as a program.  Run it with `piddigger.exe` in your PowerShell prompt.
 
-NOTE:
-* Update 26-MAR 2024: I'm trying a new packaging method that should avoid virus warnings from Defender and others.
+NOTES:
+* Update 29-SEP-2024: I've switched over to delivering PIIDigger using Embedded Python directly from Python Software Foundation.  This should avoid the usual anti-virus problems with Windows .EXE packaging methods such as PyInstaller or Py2Exe.
 * See the [ERRATA](https://github.com/kirkpatrickprice/PIIDigger/blob/main/ERRATA.md) page for information about antivirus products and packaged Python binaries.
 
 ## Usage
 Getting started with PIIDigger video is availble on [YouTube](https://youtu.be/wnUNnzy1JDw)
 ```
-usage: piidigger [-h] [-c CREATECONFIGFILE] [-d] [-f CONFIGFILE] [-p MAXPROC] [--cpu-count] [--list-datahandlers]
-                      [--list-filetypes]
+usage: piidigger.py [-h] [-c CREATECONFIGFILE] [-d] [-f CONFIGFILE] [-p MAXPROC] [--cpu-count] [--list-datahandlers]
+                    [--list-filetypes] [--version]
 
 Search the file system for Personally Identifiable Information
 
@@ -88,6 +88,7 @@ Misc. Info:
                         process' above.
   --list-datahandlers   Display the list of data handlers and exit
   --list-filetypes      Display the list of file types and exit
+  --version, -v         Display the version number and exit
 ```
 
 If a configuration file doesn't exist, PIIDigger will use a default configuration as shown below.

--- a/WINDOWS_RELEASES.md
+++ b/WINDOWS_RELEASES.md
@@ -1,23 +1,23 @@
 # Windows Releases
 ## Some general notes
 Each release consists of a standalone, 64-bit version of PIIDigger delivered as a ZIP file:
+* The file name is `piidigger-<architecture>.zip` where the only `architecture` currently supported `amd64` (testing on `win32` is forthcoming).
 * It does not require any installation.  Just download and unzip it.
-* There will be a `piddigger.exe` and an `_internal` folder.  Both the EXE and the folder are required to run. 
+* There will be `piddigger.cmd` and `piidigger.py` files and `src` and `bin` folders.  All of them are required to run. 
+* Either double-click or use PowerShell to run `piidigger.cmd`.
 * If using PIIDigger on multiple systems
     * You can create a `piidigger.toml` file with your own configuration, for instance, maybe for writing results files to a shared network folder.  See "Advanced Configuration" on the main [readme](https:\\github.com\kirkpatrickprice\PIIDigger) file for additional information.
     * You could then repackage PIIDigger into a new ZIP file
     * This configuration file will be used automatically if it exists.
 
 ## File Integrity
-* Use the Powershell command `Get-FileHash .\PIIDigger.zip` on the downloaded ZIP file to confirm the integrity of the file against the hashes listed above.
-* `piidigger.exe` in the ZIP file has also been signed by a code-signing certificate issued by SSL.Com to KirkpatrickPrice.  You can verify this signature by selecting `Properties -> Digital Signatures -> Details" and verifying it reports that "This digital signature is OK."
-* DLLs in the `_internal` folder are signed by either Microsoft or Python Software Foundation, which can be verified in the same manner as `piddigger.exe` above.
+* Use the Powershell command `Get-FileHash .\piidigger-<architecture>.zip` on the downloaded ZIP file to confirm the integrity of the file against the hashes listed on the Releases page.
+* Binary and DLL files in the `bin` folder have been signed by either Python Software Foundation or Microsoft.
 
 ## Windows Anti-Virus
-Defender and other A/V may warn that PIIDigger contains a virus.  Occasionally packaging a Python program results in this false positive.  I've taken steps to avoid this, but if you receive such a warning see the [ERRATA](https://github.com/kirkpatrickprice/PIIDigger/blob/main/ERRATA.md) for workarounds.
+Compiled Python programs are frequently treated by anti-virus vendors as suspicious.  However, by using Embedded Python directly from Python Software Foundation, we are able to avoid these detections.  Each release of PIIDigger is tested against VirusTotal, but feel free to upload it for yourself.  Be sure to report any negative findings so we can chase them down.
 
 ## Building PIIDigger from Source
-
 If you require a 32-bit version or would like to build your own executable version, the following steps will create a fresh package PIIDigger:
 
 ### TL/DR
@@ -37,7 +37,7 @@ All `typed commands` assume use of Powershell...
     cd PIIDigger
     py -m venv .venv
     .\.venv\Scripts\activate
-    pip install -e .[win,dev]
+    pip install -e .[win]
     ```
 4. Test that PIIDigger runs correctly from native Python before attempting to package an EXE
     ```
@@ -47,14 +47,13 @@ All `typed commands` assume use of Powershell...
 
     The first command should display the help content. The second command should create a file called `testfile.toml` containing a default configuration.  It can be deleted.
 
-3. Install PyInstaller to create the EXE
+3. Run the `build_windows_embedded.ps1` script.
     ```
-    pip install pyinstaller
+    .\build_windows_embedded -py_version 3.12.6 -arch win32 -venv .venv
     ```
-4. Run the build script without the Code Signing option:
-    ```
-    .\build_windows_exe.ps1 -NoCodeSign
-    ```
-    This process should take less than a minute and display several status messages.
+
+    `py_version` should match the version of Python you downloaded in step 1
+    `arch` should match of the version of Python you download (e.g. amd64 or win32)
+    `venv` should match the folder you created for your Python Virtual Environment in step 3
     
-5. `PIIDigger.zip` should be in the `dist\windows` folder.
+4. PIIDigger will be ready to run in the should be in the `dist\piidigger-<arch>` folder.  You can ZIP it, copy it, etc. for distribution to as many computers as you'd like to run it on.

--- a/build_windows_embedded.ps1
+++ b/build_windows_embedded.ps1
@@ -43,13 +43,22 @@ param(
     [string]$venv
 )
 
+#Python Embedded download URL
+$url = "https://www.python.org/ftp/python/$PyVersion/python-$PyVersion-embed-$arch.zip"
+
+# Root directory (current working directory)
 $base_dir=(Get-Location).Path
+
+# Destination directories used for copying files
+$build_dir = $base_dir + "\dist\piidigger-"+$arch
+$bin_dir = $build_dir + "\bin"
+
+# Source directories to copy files from 
 $src_dir=$base_dir+"\src"
 $venv_dir=$base_dir+"\"+$venv
 $site_packages_dir=$venv_dir+"\lib\site-packages\*"
-$build_dir = $base_dir + "\dist\"+$arch
-$bin_dir = $build_dir + "\bin"
-$url = "https://www.python.org/ftp/python/$PyVersion/python-$PyVersion-embed-$arch.zip"
+
+# Additional wrapper files needed to run PIIDigger using embedded Python
 $cmd_path = $base_dir + "\piidigger.cmd"
 $py_wrapper_path = $base_dir + "\piidigger.py"
 
@@ -87,10 +96,10 @@ write-host "Copying wrapper files: $cmd_path $cmd_path"
     Copy-Item -Path $py_wrapper_path, $cmd_path -Destination $build_dir
 
 # SIG # Begin signature block
-# MIIfYwYJKoZIhvcNAQcCoIIfVDCCH1ACAQExDzANBglghkgBZQMEAgEFADB5Bgor
+# MIIfYQYJKoZIhvcNAQcCoIIfUjCCH04CAQExDzANBglghkgBZQMEAgEFADB5Bgor
 # BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG
-# KX7zUQIBAAIBAAIBAAIBAAIBADAxMA0GCWCGSAFlAwQCAQUABCDERMERkEzaNap2
-# 1uVXKKpYtQ2ZuGSa2mQoXPlizDTWqKCCDOgwggZuMIIEVqADAgECAhAtYLGndXgb
+# KX7zUQIBAAIBAAIBAAIBAAIBADAxMA0GCWCGSAFlAwQCAQUABCCfsg95AuMG3U+v
+# CNiuagDWWktxivNUUNd4AGdTg/AdLaCCDOgwggZuMIIEVqADAgECAhAtYLGndXgb
 # zFvzMEdBS+SKMA0GCSqGSIb3DQEBCwUAMHgxCzAJBgNVBAYTAlVTMQ4wDAYDVQQI
 # DAVUZXhhczEQMA4GA1UEBwwHSG91c3RvbjERMA8GA1UECgwIU1NMIENvcnAxNDAy
 # BgNVBAMMK1NTTC5jb20gQ29kZSBTaWduaW5nIEludGVybWVkaWF0ZSBDQSBSU0Eg
@@ -159,25 +168,25 @@ write-host "Copying wrapper files: $cmd_path $cmd_path"
 # up516eDap8nMLDt7TAp4z5T3NmC2gzyKVMtODWgqlBF1JhTqIDfM63kXdlV4cW3i
 # STgzN9vkbFnHI2LmvM4uVEv9XgMqyN0eS3FE0HU+MWJliymm7STheh2ENH+kF3y0
 # rH0/NVjLw78a3Z9UVm1F5VPziIorMaPKPlDRADTsJwjDZ8Zc6Gi/zy4WZbg8Zv87
-# spWrmo2dzJTw7XhQf+xkR6OdMYIR0TCCEc0CAQEwgYwweDELMAkGA1UEBhMCVVMx
+# spWrmo2dzJTw7XhQf+xkR6OdMYIRzzCCEcsCAQEwgYwweDELMAkGA1UEBhMCVVMx
 # DjAMBgNVBAgMBVRleGFzMRAwDgYDVQQHDAdIb3VzdG9uMREwDwYDVQQKDAhTU0wg
 # Q29ycDE0MDIGA1UEAwwrU1NMLmNvbSBDb2RlIFNpZ25pbmcgSW50ZXJtZWRpYXRl
 # IENBIFJTQSBSMQIQLWCxp3V4G8xb8zBHQUvkijANBglghkgBZQMEAgEFAKB8MBAG
 # CisGAQQBgjcCAQwxAjAAMBkGCSqGSIb3DQEJAzEMBgorBgEEAYI3AgEEMBwGCisG
-# AQQBgjcCAQsxDjAMBgorBgEEAYI3AgEVMC8GCSqGSIb3DQEJBDEiBCCnHL/Gnbf7
-# my8jtmu8iMoKl+S5k6ZhST16GN6pfFLkADANBgkqhkiG9w0BAQEFAASCAYBmsuiT
-# WZL3Omvfw+Bt+gZsp51/CfVbI6ZSDRTeN3fYDey82iIcTpRtnrHtnsv6ZPPQqj6X
-# 2h9UNOI5qQjxxptnFj6HM6SBryck4iHYV9pcB/GH2BFC6AekTLBfwqJE/cLZI0i/
-# 1oWbJUx+D0p1h8F3fejafvvs8Cvq+QnKEXy5dkdvw3YPW5N90oSNtY7mnW95GWBV
-# cnc3Et34zK1x3uR3g+qICynIC+eHbfhRUqRt8LBCEbZJ0nPpYH09uz+wCj4sfwJC
-# JM0k6V/3xBilYyf5sDm8Jy4pNEz3x761KzKvrDa0ICapTZgrHBgTKSTcJ0fhQItE
-# DD8smb4dqCDfUlxrxWMSxjeF5LeCqef64H7DE33ACcSRe8cBrspSbBOl9R/Sf7/P
-# 3ryWP0iIgbBjoC5zwGzuYgfQqIjr8MKuaOiccs6C2p46t9fw3U7/cmiLcHueCxU1
-# eWrpXNd/FOTZB6mkaO4cwoPH/M01oc9Mim1Aaiu++YfKfeqFiam51Wi5cRqhgg8X
-# MIIPEwYKKwYBBAGCNwMDATGCDwMwgg7/BgkqhkiG9w0BBwKggg7wMIIO7AIBAzEN
+# AQQBgjcCAQsxDjAMBgorBgEEAYI3AgEVMC8GCSqGSIb3DQEJBDEiBCDnepYO2ZLi
+# +JMfCLjJGl1LQ9aFjLsLVa5iE6GfvSoWjTANBgkqhkiG9w0BAQEFAASCAYA6tR8t
+# RXElP3H1C4SjslyiOBnnKAHVN8LTqYtdCoiRNYppswIqDUNmKx2ZhgC1CODJxazj
+# Y0mauXWRFmAb3teEInbJQAWeZst4ckvUomAgBRyel47rDweivuD5BH6t+o/tyqJM
+# d0D3KupttUN6yMqcpWuM9t4GBK8ruMysHE0AXjv2E5caZvVpRY6orV2qsGUiPVra
+# UbtkpXds8Cp2HFXT/NewuI9yUQ8+ZGCg0zOJK84Jq4b5fRsXbcLT+T4qFvQGs/4o
+# Y830TDaUZe6pq9XBqsrJ9YQUNLhb3NTJWSl1KdTXn9h+2gvP+wyZoI6w3cS7ObQn
+# cPoK3t1J7BPxq7wdWaYcn2iey7rImff0nd7ZNQeyyBA4d9QGAvOEfe421VVs9aPQ
+# xXRiJV5B66BDelw+xUfPOtK045BnCpfLuiIEtwRY1gARfGQx1wjCgDR2AMQQPnMU
+# hQ03rtK1DDvhY7x0YKkoqwZZGccbLgxKk4Y8EJu6bHapnqb9zddC77dZko6hgg8V
+# MIIPEQYKKwYBBAGCNwMDATGCDwEwgg79BgkqhkiG9w0BBwKggg7uMIIO6gIBAzEN
 # MAsGCWCGSAFlAwQCATB3BgsqhkiG9w0BCRABBKBoBGYwZAIBAQYMKwYBBAGCqTAB
-# AwYBMDEwDQYJYIZIAWUDBAIBBQAEIEGg7yhDCSfJQsktihM2ZZCuYo+/21riyUxD
-# qPbcRWSHAgh/yW/45bl7EBgPMjAyNDA5MjkxNjAwMjFaMAMCAQGgggwAMIIE/DCC
+# AwYBMDEwDQYJYIZIAWUDBAIBBQAEIOaJ/VuFU9oIaWYowPjT3HiT0/3tVqKb17I7
+# 4FZs9H7qAggEHw3xeSfWLhgPMjAyNDA5MjkxNzEwNDVaMAMCAQGgggwAMIIE/DCC
 # AuSgAwIBAgIQWlqs6Bo1brRiho1XfeA9xzANBgkqhkiG9w0BAQsFADBzMQswCQYD
 # VQQGEwJVUzEOMAwGA1UECAwFVGV4YXMxEDAOBgNVBAcMB0hvdXN0b24xETAPBgNV
 # BAoMCFNTTCBDb3JwMS8wLQYDVQQDDCZTU0wuY29tIFRpbWVzdGFtcGluZyBJc3N1
@@ -241,18 +250,18 @@ write-host "Copying wrapper files: $cmd_path $cmd_path"
 # 0BaMqTa6LWzWItgBjGcObXeMxmbQqlEz2YtAcErkZvh0WABDDE4U8GyV/32FdaAv
 # JgTfe9MiL2nSBioYe/g5mHUSWAay/Ip1RQmQCvmF9sNfqlhJwkjy/1U1ibUkTIUB
 # X3HgymyQvqQTZLLys6pL2tCdWcjI9YuLw30rgZm8+K387L7ycUvqrmQ3ZJlujHl3
-# r1hgV76s3WwMPgKk1bAEFMj+rRXimSC+Ev30hXZdqyMdl/il5Ksd0vhGMYICWTCC
-# AlUCAQEwgYcwczELMAkGA1UEBhMCVVMxDjAMBgNVBAgMBVRleGFzMRAwDgYDVQQH
+# r1hgV76s3WwMPgKk1bAEFMj+rRXimSC+Ev30hXZdqyMdl/il5Ksd0vhGMYICVzCC
+# AlMCAQEwgYcwczELMAkGA1UEBhMCVVMxDjAMBgNVBAgMBVRleGFzMRAwDgYDVQQH
 # DAdIb3VzdG9uMREwDwYDVQQKDAhTU0wgQ29ycDEvMC0GA1UEAwwmU1NMLmNvbSBU
 # aW1lc3RhbXBpbmcgSXNzdWluZyBSU0EgQ0EgUjECEFparOgaNW60YoaNV33gPccw
 # CwYJYIZIAWUDBAIBoIIBYTAaBgkqhkiG9w0BCQMxDQYLKoZIhvcNAQkQAQQwHAYJ
-# KoZIhvcNAQkFMQ8XDTI0MDkyOTE2MDAyMVowKAYJKoZIhvcNAQk0MRswGTALBglg
-# hkgBZQMEAgGhCgYIKoZIzj0EAwIwLwYJKoZIhvcNAQkEMSIEIPNsDb0DUqVlKGrN
-# EcI28s8jm6HUhRghoQ+2fZ9x7/ILMIHJBgsqhkiG9w0BCRACLzGBuTCBtjCBszCB
+# KoZIhvcNAQkFMQ8XDTI0MDkyOTE3MTA0NVowKAYJKoZIhvcNAQk0MRswGTALBglg
+# hkgBZQMEAgGhCgYIKoZIzj0EAwIwLwYJKoZIhvcNAQkEMSIEIGZ/XNVFIxnw4fMr
+# BELRCYiq+nzBj3XC6piK9xbqFdfhMIHJBgsqhkiG9w0BCRACLzGBuTCBtjCBszCB
 # sAQgnXF/jcI3ZarOXkqw4fV115oX1Bzu2P2v7wP9Pb2JR+cwgYswd6R1MHMxCzAJ
 # BgNVBAYTAlVTMQ4wDAYDVQQIDAVUZXhhczEQMA4GA1UEBwwHSG91c3RvbjERMA8G
 # A1UECgwIU1NMIENvcnAxLzAtBgNVBAMMJlNTTC5jb20gVGltZXN0YW1waW5nIElz
-# c3VpbmcgUlNBIENBIFIxAhBaWqzoGjVutGKGjVd94D3HMAoGCCqGSM49BAMCBEgw
-# RgIhAMupnPFGAejHO5cWqGyHAm+wglJb4zJqGF2FSr+KGZ4fAiEAgBV8gXF0++iC
-# X2mKR+smVKwjEm8/IGbd2si7yVrmaNI=
+# c3VpbmcgUlNBIENBIFIxAhBaWqzoGjVutGKGjVd94D3HMAoGCCqGSM49BAMCBEYw
+# RAIgYsefqHWJU7qZ9G17RluxnFuG7e8qommRpGiAsXFsaCwCIChbzLZnMq1g/Gih
+# zZM5v2NYsqtKiT4fMH3QCPyrgXOn
 # SIG # End signature block

--- a/build_windows_embedded.ps1
+++ b/build_windows_embedded.ps1
@@ -1,0 +1,258 @@
+<#
+.SYNOPSIS
+    A Windows PowerShell script that packages PIIDigger with Embedded Python as available from python.org
+.DESCRIPTION
+    This script packages PIIDigger with the Python embedded environment from https://python.org
+
+    NOTE: This script is signed by KirkpatrickPrice using an Authenticode signature.  Use "Get-AuthenticodeSignature <script-name>" to confirm the validity of the signature.
+
+.PARAMETER pyVersion
+    Python version to download
+
+.PARAMETER arch
+    Windows architecture (win32, amd64) of Python to download.  Reference https://www.python.org/downloads/windows/ for valid values.  Defaults to amd64.
+
+.PARAMETER venv
+    Path to the Python Virtual Environment to use.  Relative to the current directory.
+
+.EXAMPLE
+    Default run with PyVersion and venv
+    
+    .\build_windows_embedded.ps1 -PyVersion="3.12.6" -venv ".venv"
+
+.EXAMPLE
+    Use win32 instead of 64-bit
+
+    .\build_windows_embedded.ps1 -PyVersion "3.12.6" -arch "win32"
+
+.LINK
+    https://github.com/kirkpatrickprice/PIIDigger
+
+.NOTES
+    Author: Randy Bartels
+    Official location:  https://github.com/kirkpatrickprice/PIIDigger
+    Bug reports:        https://github.com/kirkpatrickprice/PIIDigger/issues 
+#>
+
+param(
+    [Parameter(Mandatory)]
+    [string]$arch = "amd64",
+    [Parameter(Mandatory)]
+    [string]$pyVersion,
+    [Parameter(Mandatory)]
+    [string]$venv
+)
+
+$base_dir=(Get-Location).Path
+$src_dir=$base_dir+"\src"
+$venv_dir=$base_dir+"\"+$venv
+$site_packages_dir=$venv_dir+"\lib\site-packages\*"
+$build_dir = $base_dir + "\dist\"+$arch
+$bin_dir = $build_dir + "\bin"
+$url = "https://www.python.org/ftp/python/$PyVersion/python-$PyVersion-embed-$arch.zip"
+$cmd_path = $base_dir + "\piidigger.cmd"
+$py_wrapper_path = $base_dir + "\piidigger.py"
+
+function Write-Status {
+    param ([string]$text)
+
+    $FG_COLOR = "red"
+    Write-Host $text -ForegroundColor $FG_COLOR
+}
+
+try {
+    Invoke-WebRequest -Uri $url -OutFile python.zip
+}
+catch {
+    write-status "Error download embedded Python ($url).  Check version and architecture against https://www.python.org/downloads/windows/."
+    exit
+}
+
+# Create the new working folder and all folders leading up to it
+Write-Host "Creating new directory $bin_dir"
+New-Item -ItemType Directory -Path $bin_dir -Force
+
+# Expand the embedded Python
+Write-Host "Expanding python.zip to $bin_dir"
+Expand-Archive -Path python.zip -DestinationPath $bin_dir
+
+# Copy over the necessary PiiDigger elements
+Write-Host "Copying Site Packages: $site_packages_dir"
+    Copy-Item -Path $site_packages_dir -Destination $bin_dir -Recurse -Exclude *__pycache__*
+
+Write-Host "Copying Source Files: $src_dir"
+    Copy-Item -Path $src_dir -Destination $build_dir -Recurse
+
+write-host "Copying wrapper files: $cmd_path $cmd_path"
+    Copy-Item -Path $py_wrapper_path, $cmd_path -Destination $build_dir
+
+# SIG # Begin signature block
+# MIIfYwYJKoZIhvcNAQcCoIIfVDCCH1ACAQExDzANBglghkgBZQMEAgEFADB5Bgor
+# BgEEAYI3AgEEoGswaTA0BgorBgEEAYI3AgEeMCYCAwEAAAQQH8w7YFlLCE63JNLG
+# KX7zUQIBAAIBAAIBAAIBAAIBADAxMA0GCWCGSAFlAwQCAQUABCDERMERkEzaNap2
+# 1uVXKKpYtQ2ZuGSa2mQoXPlizDTWqKCCDOgwggZuMIIEVqADAgECAhAtYLGndXgb
+# zFvzMEdBS+SKMA0GCSqGSIb3DQEBCwUAMHgxCzAJBgNVBAYTAlVTMQ4wDAYDVQQI
+# DAVUZXhhczEQMA4GA1UEBwwHSG91c3RvbjERMA8GA1UECgwIU1NMIENvcnAxNDAy
+# BgNVBAMMK1NTTC5jb20gQ29kZSBTaWduaW5nIEludGVybWVkaWF0ZSBDQSBSU0Eg
+# UjEwHhcNMjMxMjI3MjAyMDIzWhcNMjUxMjI2MjAyMDIzWjB3MQswCQYDVQQGEwJV
+# UzESMBAGA1UECAwJVGVubmVzc2VlMRIwEAYDVQQHDAlOYXNodmlsbGUxHzAdBgNV
+# BAoMFktpcmtwYXRyaWNrIFByaWNlIEluYy4xHzAdBgNVBAMMFktpcmtwYXRyaWNr
+# IFByaWNlIEluYy4wggGiMA0GCSqGSIb3DQEBAQUAA4IBjwAwggGKAoIBgQCH4MZY
+# NZpjmSL0jBcXwN2a/Sj6Q4M0oua16QYbdW1zBK9Cw4mUKEMmo36EAaJZOyvSAdUU
+# aj2A5g50fbweYROqbeFC9L8plpS4+bLeGPTOEq1fl50VxHPCmrFOASh1mLhvIGcx
+# ZmKKr+p4sgJqpfvZKSPYkGw3EoAoJ6w2HZb7kajrdKqoaZO2IbXYVWjQHwh2EjFX
+# 3Pwt2jNQbmQKwQVYglE5REY1dk05PbtvuYD8z/JHImQUbh7UY/9vCbFUoE+Ck1J4
+# MUlO+CJNmv/XMXYOo2oCN9HY9hUc8T/1XsH2Kax7ai+nddAqPH7m7nAEtuEqQqC4
+# /FSoG4FI10bvbCAQUOAQRx0u+8xjCgJ9+hq3ZJCkWGw+Wt0av40b/fpJGtGllPDd
+# dBz/Y6UJNCbUJk8Tk0/h16Tsx/CDSHgvbq965Z54sEL8j798QDgDIv07/+amSwhv
+# IAvWbJdsDpMSdWvxtGigxkqMZ4xh1UONOCsKzRklhnFiidJ1qusAg33mifMCAwEA
+# AaOCAXMwggFvMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAUVML+EJUAk81q9efA
+# 19myS7iPDOMwWAYIKwYBBQUHAQEETDBKMEgGCCsGAQUFBzAChjxodHRwOi8vY2Vy
+# dC5zc2wuY29tL1NTTGNvbS1TdWJDQS1Db2RlU2lnbmluZy1SU0EtNDA5Ni1SMS5j
+# ZXIwUQYDVR0gBEowSDAIBgZngQwBBAEwPAYMKwYBBAGCqTABAwMBMCwwKgYIKwYB
+# BQUHAgEWHmh0dHBzOi8vd3d3LnNzbC5jb20vcmVwb3NpdG9yeTATBgNVHSUEDDAK
+# BggrBgEFBQcDAzBNBgNVHR8ERjBEMEKgQKA+hjxodHRwOi8vY3Jscy5zc2wuY29t
+# L1NTTGNvbS1TdWJDQS1Db2RlU2lnbmluZy1SU0EtNDA5Ni1SMS5jcmwwHQYDVR0O
+# BBYEFHoHVzBt4Ei4J6BKiF0XdfJ5O5Q7MA4GA1UdDwEB/wQEAwIHgDANBgkqhkiG
+# 9w0BAQsFAAOCAgEAeKQvwVT8ZkDeUVcDXW8sNAtXxBwGPDOh8x1rqNVj73uTp3g1
+# wmbOMYYZH4cnWV5/E11fwfkoNpI+fGy1YREWnzsTv+Uw5pymp9ELVrE9tzhJxgog
+# u5yM6trSMrzyCql4dWjdjElMRR/eZ0mbzhBXUIk6QcKNOm2xrUh5IOI4IJsC6rwR
+# aaAtYWQ+7f3b3iBGkzqFxmnQGsyOfrxH5Etj4awSzSFpc0jYW9SEnrN+c09YfbnO
+# Vb5bz6e23RgKBAadNbtBApWRKAxYDnwvpJzfGJxBM+oi9QZc2/loySvdi5LEcCbP
+# KFrbgakdm/ZmbS2V8NWUulnYzpSzNx8x9tw6KeGCMP/ti1dcNWULW5ItLOjjaa4T
+# VtOze4uu3Y6cqlS3/d11SLL91DJK0kqxAsejP2egwKFjaB38ShCJ/BZUwgYhlycr
+# qzgSZX9qfzzkw1XHKZer2Bfbgbwd6zkq0balgk2sAxIE9Hcc6SAWqPo9qhijjJ39
+# ZUUOJlracqAgetwg6DzBe7NMqifkXuXmVizgIFUwbYDMSs95PBsWVVGLFUqvLtvA
+# jARn7tElqmMPE24fRklS82YxO45nyalAYmrj93+7oMcXlpLVwhoFjsHRBQDcj5CG
+# Klb6IybmI8EmTPc87AetRYbmZ+v+a6vvhhECoCkdGl71Dt8M/2vJavh/9M0wggZy
+# MIIEWqADAgECAghkM1HTxzifCDANBgkqhkiG9w0BAQsFADB8MQswCQYDVQQGEwJV
+# UzEOMAwGA1UECAwFVGV4YXMxEDAOBgNVBAcMB0hvdXN0b24xGDAWBgNVBAoMD1NT
+# TCBDb3Jwb3JhdGlvbjExMC8GA1UEAwwoU1NMLmNvbSBSb290IENlcnRpZmljYXRp
+# b24gQXV0aG9yaXR5IFJTQTAeFw0xNjA2MjQyMDQ0MzBaFw0zMTA2MjQyMDQ0MzBa
+# MHgxCzAJBgNVBAYTAlVTMQ4wDAYDVQQIDAVUZXhhczEQMA4GA1UEBwwHSG91c3Rv
+# bjERMA8GA1UECgwIU1NMIENvcnAxNDAyBgNVBAMMK1NTTC5jb20gQ29kZSBTaWdu
+# aW5nIEludGVybWVkaWF0ZSBDQSBSU0EgUjEwggIiMA0GCSqGSIb3DQEBAQUAA4IC
+# DwAwggIKAoICAQCfgxNzqrDGbSHL24t6h3TQcdyOl3Ka5LuINLTdgAPGL0WkdJq/
+# Hg9Q6p5tePOf+lEmqT2d0bKUVz77OYkbkStW72fL5gvjDjmMxjX0jD3dJekBrBdC
+# fVgWQNz51ShEHZVkMGE6ZPKX13NMfXsjAm3zdetVPW+qLcSvvnSsXf5qtvzqXHnp
+# D0OctVIFD+8+sbGP0EmtpuNCGVQ/8y8Ooct8/hP5IznaJRy4PgBKOm8yMDdkHseu
+# dQfYVdIYyQ6KvKNc8HwKp4WBwg6vj5lc02AlvINaaRwlE81y9eucgJvcLGfE3ckJ
+# mNVz68Qho+Uyjj4vUpjGYDdkjLJvSlRyGMwnh/rNdaJjIUy1PWT9K6abVa8mTGC0
+# uVz+q0O9rdATZlAfC9KJpv/XgAbxwxECMzNhF/dWH44vO2jnFfF3VkopngPawism
+# YTJboFblSSmNNqf1x1KiVgMgLzh4gL32Bq5BNMuURb2bx4kYHwu6/6muakCZE93v
+# UN8BuvIE1tAx3zQ4XldbyDgeVtSsSKbt//m4wTvtwiS+RGCnd83VPZhZtEPqqmB9
+# zcLlL/Hr9dQg1Zc0bl0EawUR0tOSjAknRO1PNTFGfnQZBWLsiePqI3CY5NEv1IoT
+# GEaTZeVYc9NMPSd6Ij/D+KNVt/nmh4LsRR7Fbjp8sU65q2j3m2PVkUG8qQIDAQAB
+# o4H7MIH4MA8GA1UdEwEB/wQFMAMBAf8wHwYDVR0jBBgwFoAU3QQJB6L1en1SUxKS
+# le44gCUNplkwMAYIKwYBBQUHAQEEJDAiMCAGCCsGAQUFBzABhhRodHRwOi8vb2Nz
+# cHMuc3NsLmNvbTARBgNVHSAECjAIMAYGBFUdIAAwEwYDVR0lBAwwCgYIKwYBBQUH
+# AwMwOwYDVR0fBDQwMjAwoC6gLIYqaHR0cDovL2NybHMuc3NsLmNvbS9zc2wuY29t
+# LXJzYS1Sb290Q0EuY3JsMB0GA1UdDgQWBBRUwv4QlQCTzWr158DX2bJLuI8M4zAO
+# BgNVHQ8BAf8EBAMCAYYwDQYJKoZIhvcNAQELBQADggIBAPUPJodwr5miyvXWyfCN
+# Zj05gtOII9iCv49UhCe204MH154niU2EjlTRIO5gQ9tXQjzHsJX2vszqoz2OTwbG
+# K1mGf+tzG8rlQCbgPW/M9r1xxs19DiBAOdYF0q+UCL9/wlG3K7V7gyHwY9rlnOFp
+# LnUdTsthHvWlM98CnRXZ7WmTV7pGRS6AvGW+5xI+3kf/kJwQrfZWsqTU+tb8LryX
+# IbN2g9KR+gZQ0bGAKID+260PZ+34fdzZcFt6umi1s0pmF4/n8OdX3Wn+vF7h1Yyf
+# E7uVmhX7eSuF1W0+Z0duGwdc+1RFDxYRLhHDsLy1bhwzV5Qe/kI0Ro4xUE7bM1eV
+# +jjk5hLbq1guRbfZIsr0WkdJLCjoT4xCPGRo6eZDrBmRqccTgl/8cQo3t51Qezxd
+# 96JSgjXktefTCm9r/o35pNfVHUvnfWII+NnXrJlJ27WEQRQu9i5gl1NLmv7xiHp0
+# up516eDap8nMLDt7TAp4z5T3NmC2gzyKVMtODWgqlBF1JhTqIDfM63kXdlV4cW3i
+# STgzN9vkbFnHI2LmvM4uVEv9XgMqyN0eS3FE0HU+MWJliymm7STheh2ENH+kF3y0
+# rH0/NVjLw78a3Z9UVm1F5VPziIorMaPKPlDRADTsJwjDZ8Zc6Gi/zy4WZbg8Zv87
+# spWrmo2dzJTw7XhQf+xkR6OdMYIR0TCCEc0CAQEwgYwweDELMAkGA1UEBhMCVVMx
+# DjAMBgNVBAgMBVRleGFzMRAwDgYDVQQHDAdIb3VzdG9uMREwDwYDVQQKDAhTU0wg
+# Q29ycDE0MDIGA1UEAwwrU1NMLmNvbSBDb2RlIFNpZ25pbmcgSW50ZXJtZWRpYXRl
+# IENBIFJTQSBSMQIQLWCxp3V4G8xb8zBHQUvkijANBglghkgBZQMEAgEFAKB8MBAG
+# CisGAQQBgjcCAQwxAjAAMBkGCSqGSIb3DQEJAzEMBgorBgEEAYI3AgEEMBwGCisG
+# AQQBgjcCAQsxDjAMBgorBgEEAYI3AgEVMC8GCSqGSIb3DQEJBDEiBCCnHL/Gnbf7
+# my8jtmu8iMoKl+S5k6ZhST16GN6pfFLkADANBgkqhkiG9w0BAQEFAASCAYBmsuiT
+# WZL3Omvfw+Bt+gZsp51/CfVbI6ZSDRTeN3fYDey82iIcTpRtnrHtnsv6ZPPQqj6X
+# 2h9UNOI5qQjxxptnFj6HM6SBryck4iHYV9pcB/GH2BFC6AekTLBfwqJE/cLZI0i/
+# 1oWbJUx+D0p1h8F3fejafvvs8Cvq+QnKEXy5dkdvw3YPW5N90oSNtY7mnW95GWBV
+# cnc3Et34zK1x3uR3g+qICynIC+eHbfhRUqRt8LBCEbZJ0nPpYH09uz+wCj4sfwJC
+# JM0k6V/3xBilYyf5sDm8Jy4pNEz3x761KzKvrDa0ICapTZgrHBgTKSTcJ0fhQItE
+# DD8smb4dqCDfUlxrxWMSxjeF5LeCqef64H7DE33ACcSRe8cBrspSbBOl9R/Sf7/P
+# 3ryWP0iIgbBjoC5zwGzuYgfQqIjr8MKuaOiccs6C2p46t9fw3U7/cmiLcHueCxU1
+# eWrpXNd/FOTZB6mkaO4cwoPH/M01oc9Mim1Aaiu++YfKfeqFiam51Wi5cRqhgg8X
+# MIIPEwYKKwYBBAGCNwMDATGCDwMwgg7/BgkqhkiG9w0BBwKggg7wMIIO7AIBAzEN
+# MAsGCWCGSAFlAwQCATB3BgsqhkiG9w0BCRABBKBoBGYwZAIBAQYMKwYBBAGCqTAB
+# AwYBMDEwDQYJYIZIAWUDBAIBBQAEIEGg7yhDCSfJQsktihM2ZZCuYo+/21riyUxD
+# qPbcRWSHAgh/yW/45bl7EBgPMjAyNDA5MjkxNjAwMjFaMAMCAQGgggwAMIIE/DCC
+# AuSgAwIBAgIQWlqs6Bo1brRiho1XfeA9xzANBgkqhkiG9w0BAQsFADBzMQswCQYD
+# VQQGEwJVUzEOMAwGA1UECAwFVGV4YXMxEDAOBgNVBAcMB0hvdXN0b24xETAPBgNV
+# BAoMCFNTTCBDb3JwMS8wLQYDVQQDDCZTU0wuY29tIFRpbWVzdGFtcGluZyBJc3N1
+# aW5nIFJTQSBDQSBSMTAeFw0yNDAyMTkxNjE4MTlaFw0zNDAyMTYxNjE4MThaMG4x
+# CzAJBgNVBAYTAlVTMQ4wDAYDVQQIDAVUZXhhczEQMA4GA1UEBwwHSG91c3RvbjER
+# MA8GA1UECgwIU1NMIENvcnAxKjAoBgNVBAMMIVNTTC5jb20gVGltZXN0YW1waW5n
+# IFVuaXQgMjAyNCBFMTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABKdhcvUw6XrE
+# gxSWBULj3Oid25Rt2TJvSmLLaLy3cmVATADvhyMryD2ZELwYfVwABUwivwzYd1ml
+# WCRXUtcEsHyjggFaMIIBVjAfBgNVHSMEGDAWgBQMnRAljpqnG5mHQ88IfuG9gZD0
+# zzBRBggrBgEFBQcBAQRFMEMwQQYIKwYBBQUHMAKGNWh0dHA6Ly9jZXJ0LnNzbC5j
+# b20vU1NMLmNvbS10aW1lU3RhbXBpbmctSS1SU0EtUjEuY2VyMFEGA1UdIARKMEgw
+# PAYMKwYBBAGCqTABAwYBMCwwKgYIKwYBBQUHAgEWHmh0dHBzOi8vd3d3LnNzbC5j
+# b20vcmVwb3NpdG9yeTAIBgZngQwBBAIwFgYDVR0lAQH/BAwwCgYIKwYBBQUHAwgw
+# RgYDVR0fBD8wPTA7oDmgN4Y1aHR0cDovL2NybHMuc3NsLmNvbS9TU0wuY29tLXRp
+# bWVTdGFtcGluZy1JLVJTQS1SMS5jcmwwHQYDVR0OBBYEFFBPJKzvtT5jEyMJkibs
+# ujqW5F0iMA4GA1UdDwEB/wQEAwIHgDANBgkqhkiG9w0BAQsFAAOCAgEAmKCPAwCR
+# vKvEZEF/QiHiv6tsIHnuVO7BWILqcfZ9lJyIyiCmpLOtJ5VnZ4hvm+GP2tPuOpZd
+# mfTYWdyzhhOsDVDLElbfrKMLiOXn9uwUJpa5fMZe3Zjoh+n/8DdnSw1MxZNMGhuZ
+# x4zeyqei91f1OhEU/7b2vnJCc9yBFMjY++tVKovFj0TKT3/Ry+Izdbb1gGXTzQQ1
+# uVFy7djxGx/NG1VP/aye4OhxHG9FiZ3RM9oyAiPbEgjrnVCc+nWGKr3FTQDKi8vN
+# uyLnCVHkiniL+Lz7H4fBgk163Llxi11Ynu5A/phpm1b+M2genvqo1+2r8iVLHrER
+# gFGMUHEdKrZ/OFRDmgFrCTY6xnaPTA5/ursCqMK3q3/59uZaOsBZhZkaP9EuOW2p
+# 0U8Gkgqp2GNUjFoaDNWFoT/EcoGDiTgN8VmQFgn0Fa4/3dOb6lpYEPBcjsWDdqUa
+# xugStY9aW/AwCal4lSN4otljbok8u31lZx5NVa4jK6N6upvkgyZ6osmbmIWr9DLh
+# g8bI+KiXDnDWT0547gSuZLYUq+TV6O/DhJZH5LVXJaeS1jjjZZqhK3EEIJVZl0xY
+# V4H4Skvy6hA2rUyFK3+whSNS52TJkshsxVCOPtvqA9ecPqZLwWBaIICG4zVr+GAD
+# 7qjWwlaLMd2ZylgOHI3Oit/0pVETqJHutyYwggb8MIIE5KADAgECAhBtUhhwh+gj
+# TYVgANCAj5NWMA0GCSqGSIb3DQEBCwUAMHwxCzAJBgNVBAYTAlVTMQ4wDAYDVQQI
+# DAVUZXhhczEQMA4GA1UEBwwHSG91c3RvbjEYMBYGA1UECgwPU1NMIENvcnBvcmF0
+# aW9uMTEwLwYDVQQDDChTU0wuY29tIFJvb3QgQ2VydGlmaWNhdGlvbiBBdXRob3Jp
+# dHkgUlNBMB4XDTE5MTExMzE4NTAwNVoXDTM0MTExMjE4NTAwNVowczELMAkGA1UE
+# BhMCVVMxDjAMBgNVBAgMBVRleGFzMRAwDgYDVQQHDAdIb3VzdG9uMREwDwYDVQQK
+# DAhTU0wgQ29ycDEvMC0GA1UEAwwmU1NMLmNvbSBUaW1lc3RhbXBpbmcgSXNzdWlu
+# ZyBSU0EgQ0EgUjEwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCuURAT
+# 0vk8IKAghd7JUBxkyeH9xek0/wp/MUjoclrFXqhh/fGH91Fc+7fm0MHCE7A+wmOi
+# qBj9ODrJAYGq3rm33jCnHSsCBNWAQYyoauLq8IjqsS1JlXL29qDNMMdwZ8UNzQS7
+# vWZMDJ40JSGNphMGTIA2qn2bohGtgRc4p1395ESypUOaGvJ3t0FNL3BuKmb6YctM
+# cQUF2sqooMzd89h0E6ujdvBDo6ZwNnWoxj7YmfWjSXg33A5GuY9ym4QZM5OEVgo8
+# ebz/B+gyhyCLNNhh4Mb/4xvCTCMVmNYrBviGgdPZYrym8Zb84TQCmSuX0JlLLa6W
+# K1aO6qlwISbb9bVGh866ekKblC/XRP20gAu1CjvcYciUgNTrGFg8f8AJgQPOCc1/
+# CCdaJSYwhJpSdheKOnQgESgNmYZPhFOC6IKaMAUXk5U1tjTcFCgFvvArXtK4azAW
+# UOO1Y3fdldIBL6LjkzLUCYJNkFXqhsBVcPMuB0nUDWvLJfPimstjJ8lF4S6ECxWn
+# lWi7OElVwTnt1GtRqeY9ydvvGLntU+FecK7DbqHDUd366UreMkSBtzevAc9aqoZP
+# njVMjvFqV1pYOjzmTiVHZtAc80bAfFe5LLfJzPI6DntNyqobpwTevQpHqPDN9qqN
+# O83r3kaw8A9j+HZiSw2AX5cGdQP0kG0vhzfgBwIDAQABo4IBgTCCAX0wEgYDVR0T
+# AQH/BAgwBgEB/wIBADAfBgNVHSMEGDAWgBTdBAkHovV6fVJTEpKV7jiAJQ2mWTCB
+# gwYIKwYBBQUHAQEEdzB1MFEGCCsGAQUFBzAChkVodHRwOi8vd3d3LnNzbC5jb20v
+# cmVwb3NpdG9yeS9TU0xjb21Sb290Q2VydGlmaWNhdGlvbkF1dGhvcml0eVJTQS5j
+# cnQwIAYIKwYBBQUHMAGGFGh0dHA6Ly9vY3Nwcy5zc2wuY29tMD8GA1UdIAQ4MDYw
+# NAYEVR0gADAsMCoGCCsGAQUFBwIBFh5odHRwczovL3d3dy5zc2wuY29tL3JlcG9z
+# aXRvcnkwEwYDVR0lBAwwCgYIKwYBBQUHAwgwOwYDVR0fBDQwMjAwoC6gLIYqaHR0
+# cDovL2NybHMuc3NsLmNvbS9zc2wuY29tLXJzYS1Sb290Q0EuY3JsMB0GA1UdDgQW
+# BBQMnRAljpqnG5mHQ88IfuG9gZD0zzAOBgNVHQ8BAf8EBAMCAYYwDQYJKoZIhvcN
+# AQELBQADggIBAJIZdQ2mWkLPGQfZ8vyU+sCb8BXpRJZaL3Ez3VDlE3uZk3cPxPty
+# bVfLuqaci0W6SB22JTMttCiQMnIVOsXWnIuAbD/aFTcUkTLBI3xys+wEajzXaXJY
+# WACDS47BRjDtYlDW14gLJxf8W6DQoH3jHDGGy8kGJFOlDKG7/YrK7UGfHtBAEDVe
+# 6lyZ+FtCsrk7dD/IiL/+Q3Q6SFASJLQ2XI89ihFugdYL77CiDNXrI2MFspQGswXE
+# AGpHuaQDTHUp/LdR3TyrIsLlnzoLskUGswF/KF8+kpWUiKJNC4rPWtNrxlbXYRGg
+# dEdx8SMjUTDClldcrknlFxbqHsVmr9xkT2QtFmG+dEq1v5fsIK0vHaHrWjMMmaJ9
+# i+4qGJSD0stYfQ6v0PddT7EpGxGd867Ada6FZyHwbuQSadMb0K0P0OC2r7rwqBUe
+# 0BaMqTa6LWzWItgBjGcObXeMxmbQqlEz2YtAcErkZvh0WABDDE4U8GyV/32FdaAv
+# JgTfe9MiL2nSBioYe/g5mHUSWAay/Ip1RQmQCvmF9sNfqlhJwkjy/1U1ibUkTIUB
+# X3HgymyQvqQTZLLys6pL2tCdWcjI9YuLw30rgZm8+K387L7ycUvqrmQ3ZJlujHl3
+# r1hgV76s3WwMPgKk1bAEFMj+rRXimSC+Ev30hXZdqyMdl/il5Ksd0vhGMYICWTCC
+# AlUCAQEwgYcwczELMAkGA1UEBhMCVVMxDjAMBgNVBAgMBVRleGFzMRAwDgYDVQQH
+# DAdIb3VzdG9uMREwDwYDVQQKDAhTU0wgQ29ycDEvMC0GA1UEAwwmU1NMLmNvbSBU
+# aW1lc3RhbXBpbmcgSXNzdWluZyBSU0EgQ0EgUjECEFparOgaNW60YoaNV33gPccw
+# CwYJYIZIAWUDBAIBoIIBYTAaBgkqhkiG9w0BCQMxDQYLKoZIhvcNAQkQAQQwHAYJ
+# KoZIhvcNAQkFMQ8XDTI0MDkyOTE2MDAyMVowKAYJKoZIhvcNAQk0MRswGTALBglg
+# hkgBZQMEAgGhCgYIKoZIzj0EAwIwLwYJKoZIhvcNAQkEMSIEIPNsDb0DUqVlKGrN
+# EcI28s8jm6HUhRghoQ+2fZ9x7/ILMIHJBgsqhkiG9w0BCRACLzGBuTCBtjCBszCB
+# sAQgnXF/jcI3ZarOXkqw4fV115oX1Bzu2P2v7wP9Pb2JR+cwgYswd6R1MHMxCzAJ
+# BgNVBAYTAlVTMQ4wDAYDVQQIDAVUZXhhczEQMA4GA1UEBwwHSG91c3RvbjERMA8G
+# A1UECgwIU1NMIENvcnAxLzAtBgNVBAMMJlNTTC5jb20gVGltZXN0YW1waW5nIElz
+# c3VpbmcgUlNBIENBIFIxAhBaWqzoGjVutGKGjVd94D3HMAoGCCqGSM49BAMCBEgw
+# RgIhAMupnPFGAejHO5cWqGyHAm+wglJb4zJqGF2FSr+KGZ4fAiEAgBV8gXF0++iC
+# X2mKR+smVKwjEm8/IGbd2si7yVrmaNI=
+# SIG # End signature block

--- a/piidigger.cmd
+++ b/piidigger.cmd
@@ -1,0 +1,4 @@
+@echo off
+rem This script is a wrapper to start PIIDIgger using the embedded Python binaries in the bin\ directory
+rem %* will pass all command line arguments to PIIDigger for processing
+bin\python.exe piidigger.py %*


### PR DESCRIPTION
closes #26 

Scripted the Windows Embedded Python packaging method in both `build_windows_embedded.ps1` and in GitHub Actions.  Commented out the Windows EXE build method from `build-packkage.yml`.  Updated documentation to reflect Embedded Python changes.