### PR TITLE
Bump Ubuntu running to ubuntu 22.04

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-ubuntu:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
Bumping the GH runner to Ubuntu 22.04 as their 20.04 runner has been decommissioned.